### PR TITLE
Selenium 4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ src/**/*.ks
 
 out/
 .DS_Store
+
+#Sourcetrail
+*.srctrlbm
+*.srctrldb
+*.srctrlprj

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'com.vladmihalcea:hibernate-types-52:2.7.0'
 
     implementation 'org.testcontainers:junit-jupiter:1.15.3'
-    implementation 'org.seleniumhq.selenium:selenium-java:3.141.59'
+    implementation 'org.seleniumhq.selenium:selenium-java:4.1.2'
     implementation 'com.epam.healenium:tree-comparing:0.4.9'
     implementation 'org.projectlombok:lombok:1.18.8'
     implementation 'org.mapstruct:mapstruct:1.3.1.Final'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
 }
 
 group 'com.epam.healenium'
-version '1.0-SNAPSHOT'
 
 sourceCompatibility = 1.8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.warning.mode=all
+#version of this artifact
+version=3.2.1-SNAPSHOT

--- a/src/test/java/com/epam/healenium/util/PathUtils.java
+++ b/src/test/java/com/epam/healenium/util/PathUtils.java
@@ -30,7 +30,7 @@ public class PathUtils {
         ResourceReader.readResource("itemsWithAttributes.js", s -> s.collect(Collectors.joining()));
 
     public List<Node> getNodePath(WebDriver webDriver, WebElement webElement) {
-        log.debug("* getNodePath start: " + LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_TIME));
+        log.debug("* getNodePath start: {}", LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_TIME));
         JavascriptExecutor executor = (JavascriptExecutor) webDriver;
         String data = (String) executor.executeScript(SCRIPT, webElement);
         List<Node> path = new LinkedList<>();
@@ -47,7 +47,7 @@ public class PathUtils {
         } catch (Exception ex) {
             log.error("Failed to get element node path!", ex);
         }
-        log.debug("* getNodePath finish: " + LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_TIME));
+        log.debug("* getNodePath finish: {}", LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_TIME));
         return path;
     }
 


### PR DESCRIPTION
- upgrade to Selenum 4 dependency
- use slf4j pattern for loggings instead of string concatenation
- extract version into properties file and upgrade to 3.2.1-SNAPSHOT
- enable all Gradle warnings