### PR TITLE
Support path separator of Windows

### DIFF
--- a/src/main/java/com/epam/healenium/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/epam/healenium/service/impl/ReportServiceImpl.java
@@ -127,7 +127,7 @@ public class ReportServiceImpl implements ReportService {
 
     private String transformPath(String sourcePath) {
         try {
-            List<String> dirs = Arrays.asList(sourcePath.split("/"));
+            List<String> dirs = Arrays.asList(sourcePath.split("\\\\|/"));
             Collections.reverse(dirs);
             String name = dirs.get(0);
             String uid = dirs.get(1);


### PR DESCRIPTION
This function is only applicable for Linux file path with path separator is '/'. We need to support for Windows file path with path separator is '\\'