### PR TITLE
fix: support base url for assets

### DIFF
--- a/src/main/java/com/epam/healenium/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/epam/healenium/service/impl/ReportServiceImpl.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -30,6 +31,9 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class ReportServiceImpl implements ReportService {
+
+    @Value("${app.baseUrl}")
+    private String baseUrl;
 
     private final ReportRepository reportRepository;
     private final HealingResultRepository resultRepository;
@@ -126,7 +130,8 @@ public class ReportServiceImpl implements ReportService {
     private String transformPath(String sourcePath) {
         try {
             int i = sourcePath.lastIndexOf("screenshots");
-            return sourcePath.substring(i - 1);
+            String imagePath = sourcePath.substring(i - 1);
+            return String.format("%s%s", baseUrl, imagePath);
         } catch (Exception e) {
             log.warn("[Build Report] Error transform sourcePath: {}", sourcePath);
             return sourcePath;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,7 @@ app:
     allow: ${COLLECT_METRICS:true}
   healing:
     elements: ${FIND_ELEMENTS_AUTO_HEALING:false}
+  baseUrl: ${BASE_URL:/}
 
 cloud:
   aws:


### PR DESCRIPTION
Hi,

When I use Healenium backend service at root, images are working perfectly but when I add a subdirectory to path it won't display the images.

Example:
localhost/screenshots -> working
localhost/healenium/screenshots -> not working

The idea is to add a base url in the configuration file to concat it with screenshot path.